### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/zh/guide/getting-started.md
+++ b/docs/zh/guide/getting-started.md
@@ -12,7 +12,7 @@ VuePress v2 目前仍处于 RC (Release Candidate) 阶段。你已经可以用�
 
 ### 依赖环境
 
-- [Node.js v18.16.0+](https://nodejs.org/)
+- [Node.js v20.16.0+](https://nodejs.org/)
 - 包管理器，如 [pnpm](https://pnpm.io/zh/)、[yarn](https://classic.yarnpkg.com/en/)、[npm](https://www.npmjs.com/) 等。
 
 ::: tip


### PR DESCRIPTION
You're right, I'll just upgrade to v20.16.0. But the official website documentation requires Node.js v18.16.0+, which is sufficient. I was originally v18.17.0. It seems that the official website has not been updated.

Upgrade node version

https://github.com/vuepress/core/discussions/1597

