### PR TITLE
Add DeployHQ Deployment Guide

### DIFF
--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -231,3 +231,25 @@ You should disable Pretty URLs in the "Site Configuration" → "Build & Deploy" 
 ## CloudRay
 
 See [Deploy Your VuePress Site With CloudRay](https://cloudray.io/articles/how-to-deploy-your-vuepress-site)
+
+## DeployHQ
+
+[DeployHQ](https://www.deployhq.com) is a Git-based deployment platform that builds your VuePress site and transfers the output to your own server over SSH/SFTP/FTP, or to S3, Azure Blob, or Rackspace Cloud Files. It supports build pipelines, atomic releases, one-click rollback, and multiple environments (e.g. staging and production) mapped to different branches of your repository.
+
+1. [Sign up for DeployHQ](https://www.deployhq.com/signup) and create a new project, connecting it to your GitHub, GitLab, or Bitbucket repository that contains your VuePress site.
+
+2. Add a build pipeline command so DeployHQ builds your site before transferring it:
+
+   ```bash
+   pnpm install --frozen-lockfile && pnpm docs:build
+   ```
+
+3. Set the build output directory to `docs/.vuepress/dist`. DeployHQ will only transfer files from this directory to your server.
+
+4. Add a server in your project settings (SSH/SFTP/FTP, S3, Azure Blob, or Rackspace Cloud Files), map it to the branch you want to deploy from (for example `main` for production), and set the deployment path to your web server's document root.
+
+5. Trigger a deployment manually, or enable automatic deployments so every push to the mapped branch is built and shipped automatically.
+
+::: tip
+Please refer to the [DeployHQ VuePress deployment guide](https://www.deployhq.com/guides/vuepress) for more details.
+:::

--- a/docs/zh/guide/deployment.md
+++ b/docs/zh/guide/deployment.md
@@ -232,8 +232,6 @@ heroku login
 
 请查看 [Deploy Your VuePress Site With CloudRay](https://cloudray.io/articles/how-to-deploy-your-vuepress-site) 。
 
-<!-- 下列平台是中文文档特有的，放在最下方 -->
-
 ## DeployHQ
 
 [DeployHQ](https://www.deployhq.com) 是一个基于 Git 的部署平台，可以构建你的 VuePress 站点，并通过 SSH/SFTP/FTP 将构建产物传输到你自己的服务器，也支持 S3、Azure Blob 或 Rackspace Cloud Files。它支持构建流水线、原子发布、一键回滚，以及映射到仓库不同分支的多环境（例如 staging 和 production）。
@@ -255,6 +253,8 @@ heroku login
 ::: tip
 更多详细信息请参阅 [DeployHQ 的 VuePress 部署指南](https://www.deployhq.com/guides/vuepress)。
 :::
+
+<!-- 下列平台是中文文档特有的，放在最下方 -->
 
 ## 云开发 CloudBase
 

--- a/docs/zh/guide/deployment.md
+++ b/docs/zh/guide/deployment.md
@@ -234,6 +234,28 @@ heroku login
 
 <!-- 下列平台是中文文档特有的，放在最下方 -->
 
+## DeployHQ
+
+[DeployHQ](https://www.deployhq.com) 是一个基于 Git 的部署平台，可以构建你的 VuePress 站点，并通过 SSH/SFTP/FTP 将构建产物传输到你自己的服务器，也支持 S3、Azure Blob 或 Rackspace Cloud Files。它支持构建流水线、原子发布、一键回滚，以及映射到仓库不同分支的多环境（例如 staging 和 production）。
+
+1. [注册 DeployHQ 账号](https://www.deployhq.com/signup) 并创建一个新项目，关联到包含你 VuePress 站点的 GitHub、GitLab 或 Bitbucket 仓库。
+
+2. 添加构建流水线命令，让 DeployHQ 在传输前构建你的站点：
+
+   ```bash
+   pnpm install --frozen-lockfile && pnpm docs:build
+   ```
+
+3. 将构建输出目录设置为 `docs/.vuepress/dist`。DeployHQ 只会将该目录中的文件传输到你的服务器。
+
+4. 在项目设置中添加一个服务器（SSH/SFTP/FTP、S3、Azure Blob 或 Rackspace Cloud Files），映射到你希望部署的分支（例如生产环境使用 `main`），并将部署路径设置为你 Web 服务器的文档根目录。
+
+5. 手动触发一次部署，或启用自动部署，让每次推送到映射分支都会自动构建并发布。
+
+::: tip
+更多详细信息请参阅 [DeployHQ 的 VuePress 部署指南](https://www.deployhq.com/guides/vuepress)。
+:::
+
 ## 云开发 CloudBase
 
 [云开发 CloudBase](https://cloudbase.net/?site=vuepress) 是一个云原生一体化的 Serverless 云平台，支持静态网站、容器等多种托管能力，并提供简便的部署工具 [CloudBase Framework](https://cloudbase.net/framework.html?site=vuepress) 来一键部署应用。


### PR DESCRIPTION
Adds a new `## DeployHQ` section to both the English and Simplified Chinese versions of the deployment guide, matching the format of the existing CloudRay / Heroku / Netlify entries (short intro + numbered setup steps + `::: tip` block linking to the platform's own VuePress deployment guide).

[DeployHQ](https://www.deployhq.com) is a Git-based deployment platform that builds VuePress sites in a managed environment and transfers the `docs/.vuepress/dist` output to a user-owned server over SSH/SFTP/FTP — or to S3, Azure Blob, or Rackspace Cloud Files. It's the BYO-server complement to the existing managed-host entries on this page (no managed CDN, no vendor lock-in to a specific hosting platform). The full setup walkthrough lives on the DeployHQ documentation site at https://www.deployhq.com/guides/vuepress.

### Files changed

- `docs/guide/deployment.md` — new `## DeployHQ` section appended after `## CloudRay` (the current last international entry)
- `docs/zh/guide/deployment.md` — new `## DeployHQ` section inserted between `## CloudRay` and `## 云开发 CloudBase` (preserving the convention of grouping international providers before China-specific ones)

### Bilingual change per project convention

Both English and Chinese files are modified in this single PR — adding only one side would be inconsistent with the project's bilingual convention (PR #52 was previously closed for a zh-only change). The Chinese translation was machine-assisted; corrections from a native Chinese speaker on the review are welcome before merge.

### Disclosure

This PR was drafted with AI assistance and reviewed by the contributor before opening. The English section was authored directly; the Chinese section is a translation of the same content using the technical terms VuePress's existing Chinese docs use elsewhere on this page.
